### PR TITLE
Use python:3-slim to reduce by 5 the size of builded image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3-slim
 
 WORKDIR /opt/prometheus_aci_exporter
 


### PR DESCRIPTION
I have tested the python:3-slim, that result to get an Docker image of 180MB instead of more than 900MB. 