### PR TITLE
Remove urllib3 warning in Docker container for SSL untrusted certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3
 
+ENV PYTHONWARNINGS "ignore:Unverified HTTPS request"
+
+
 WORKDIR /opt/prometheus_aci_exporter
 
 COPY requirements.txt ./


### PR DESCRIPTION
I have added the PYTHONWARNING environement variable to remove the SSL untrusted certificate warning, to not have a flood of warning in the logs.