### PR TITLE
Modify regex in exemple file to distinguish fan id for APIC 

### DIFF
--- a/examples/aci.yml
+++ b/examples/aci.yml
@@ -207,7 +207,7 @@ common_queries:
         help_text: The current Pulse-Width Modulation value of the fan.
     labels:
       - property_name: dn
-        regex: "^topology/pod-(?P<pod>[1-9][0-9]*)/node-(?P<node>[1-9][0-9]*)/sys/ch/(?P<slotType>[a-z]+)-(?P<slot>[^/]+)/"
+        regex: "^topology/pod-(?P<pod>[1-9][0-9]*)/node-(?P<node>[1-9][0-9]*)/sys/ch/(?P<slotType>[a-z]+)-(?P<slot>[^/]+)/ft/fan-(?P<fan>[1-9][0-9]*)/"
   psu_power_stats:
     class_name: eqptPsPower5min
     metrics:


### PR DESCRIPTION
Correct issue #6

Need to get the fanId from the URL to distinguish FAN for APIC (all fans
is in same slot for the api.

I have corrected the example file to not have issue for newcomers.

Signed-off-by: Cyril Grosjean <cyril.grosjean@wifirst.fr>