### PR TITLE
fix error

### DIFF
--- a/prometheus_aci_exporter.py
+++ b/prometheus_aci_exporter.py
@@ -484,10 +484,10 @@ class AciCollector(object):
                 self.regex_cache[regex_str] = regex
 
             match = regex.match(property_value)
-            if match is not None:
+            if str(match) != "None" or match is not None:
                 match_dict = match.groupdict()
                 property_value = {k: v if v is not None else "" for (k, v) in match_dict.items()}
-            elif regex_must_match:
+            elif str(regex_must_match) == "False" or regex_must_match:
                 # it didn't match, though
                 return None
 


### PR DESCRIPTION
the 'None' value returned from regex.match() didn't handle as expected in those if condition, so errors happened. As a workaround, the type of return value from regex.match() could convert as a string.