### PR TITLE
add support for decoding timestamps

### DIFF
--- a/examples/aci.yml
+++ b/examples/aci.yml
@@ -100,6 +100,12 @@ common_queries:
           'down': 1
           'up': 2
           'link-up': 3
+      - key: aci_interface_last_link_state_change_timestamp
+        property_name: lastLinkStChg
+        type: gauge
+        help_text: The Unix timestamp (seconds since Jan 01 1970 midnight UTC)
+          of the time when the interface's link state last changed.
+        value_type: timestamp
     labels:
       - property_name: dn
         regex: "^topology/pod-(?P<pod>[1-9][0-9]*)/node-(?P<node>[1-9][0-9]*)/sys/phys-\\[(?P<interface>[^\\]]+)\\]/"

--- a/prometheus_aci_exporter.py
+++ b/prometheus_aci_exporter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from itertools import chain
 import logging
@@ -426,6 +427,10 @@ class AciCollector(object):
             labels['className'] = class_name
 
 
+    def parse_timestamp(self, timestamp_str: str) -> float:
+        return datetime.datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%S.%f%z").timestamp()
+
+
     def process_value(
             self, attributes: Dict[str, JsonType], definition: Dict[str, JsonType],
             property_name_suffix: str = ""
@@ -448,6 +453,7 @@ class AciCollector(object):
                 'str': str,
                 'int': int,
                 'float': float,
+                'timestamp': self.parse_timestamp,
             }.get(type_key, None)
             if type_func is None:
                 raise ValueError(f"unknown type conversion function {type_func!r}")


### PR DESCRIPTION
Prometheus handles timestamps like Unix, representing them as seconds
since 1970-01-01T00:00:00Z (see e.g. the built-in function time()). ACI
provides them in the RFC3339 format instead. Implement support for a new
value_type value ("timestamp") which converts from RFC3339 to Unix
timestamps. Additionally, add a metric to the sample configuration that
logs the last link state change timestamp.